### PR TITLE
Add pytest dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ This project is licensed under the MIT License. See the [LICENSE](LICENSE) file 
 
 ## Installation
 
-Install the required Python packages:
+Install the required Python packages (including `pytest` for running the tests):
 
 ```bash
 pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ seaborn
 xlsxwriter
 scipy
 statsmodels
+pytest


### PR DESCRIPTION
## Summary
- add `pytest` to requirements
- mention that `pip install -r requirements.txt` installs `pytest`

## Testing
- `python -m pytest -q tests` *(fails: No module named pytest)*